### PR TITLE
Converted to use netstandard and dotnetcore supporting mongodb driver

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,5 @@
 {
-	"sdk": {
-		"version": "1.0.0-rc1-update1"
-	}
+  "sdk": {
+    "version": "1.0.0-preview2-003121"
+  }
 }

--- a/src/AspNetCore.Identity.MongoDB/AspNetCore.Identity.MongoDB.sln
+++ b/src/AspNetCore.Identity.MongoDB/AspNetCore.Identity.MongoDB.sln
@@ -1,0 +1,27 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "AspNetCore.Identity.MongoDB", "AspNetCore.Identity.MongoDB.xproj", "{5488A9D3-E575-4262-AEE3-6BFD4563EF3A}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{ED796E94-9E2D-496A-B496-61B931D2860C}"
+	ProjectSection(SolutionItems) = preProject
+		..\..\global.json = ..\..\global.json
+	EndProjectSection
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{5488A9D3-E575-4262-AEE3-6BFD4563EF3A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5488A9D3-E575-4262-AEE3-6BFD4563EF3A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5488A9D3-E575-4262-AEE3-6BFD4563EF3A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5488A9D3-E575-4262-AEE3-6BFD4563EF3A}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/src/AspNetCore.Identity.MongoDB/AspNetCore.Identity.MongoDB.xproj
+++ b/src/AspNetCore.Identity.MongoDB/AspNetCore.Identity.MongoDB.xproj
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>5488a9d3-e575-4262-aee3-6bfd4563ef3a</ProjectGuid>
+    <RootNamespace>AspNetCore.Identity.MongoDB</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/src/AspNetCore.Identity.MongoDB/Models/MongoUserClaim.cs
+++ b/src/AspNetCore.Identity.MongoDB/Models/MongoUserClaim.cs
@@ -36,14 +36,14 @@ namespace Dnx.Identity.MongoDB.Models
 
         public bool Equals(MongoUserClaim other)
         {
-            return other.ClaimType.Equals(ClaimType, StringComparison.InvariantCultureIgnoreCase)
-                && other.ClaimValue.Equals(ClaimValue, StringComparison.InvariantCultureIgnoreCase);
+            return other.ClaimType.Equals(ClaimType)
+                && other.ClaimValue.Equals(ClaimValue);
         }
 
         public bool Equals(Claim other)
         {
-            return other.Type.Equals(ClaimType, StringComparison.InvariantCultureIgnoreCase)
-                && other.Value.Equals(ClaimValue, StringComparison.InvariantCultureIgnoreCase);
+            return other.Type.Equals(ClaimType)
+                && other.Value.Equals(ClaimValue);
         }
     }
 }

--- a/src/AspNetCore.Identity.MongoDB/Models/MongoUserContactRecord.cs
+++ b/src/AspNetCore.Identity.MongoDB/Models/MongoUserContactRecord.cs
@@ -42,7 +42,7 @@ namespace Dnx.Identity.MongoDB.Models
 
         public bool Equals(MongoUserEmail other)
         {
-            return other.Value.Equals(Value, StringComparison.InvariantCultureIgnoreCase);
+            return other.Value.Equals(Value);
         }
     }
 }

--- a/src/AspNetCore.Identity.MongoDB/Models/MongoUserLogin.cs
+++ b/src/AspNetCore.Identity.MongoDB/Models/MongoUserLogin.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.AspNet.Identity;
-using System;
+﻿using System;
+using Microsoft.AspNetCore.Identity;
 
 namespace Dnx.Identity.MongoDB.Models
 {
@@ -23,14 +23,14 @@ namespace Dnx.Identity.MongoDB.Models
 
         public bool Equals(MongoUserLogin other)
         {
-            return other.LoginProvider.Equals(LoginProvider, StringComparison.InvariantCultureIgnoreCase)
-                && other.ProviderKey.Equals(ProviderKey, StringComparison.InvariantCulture);
+            return other.LoginProvider.Equals(LoginProvider)
+                && other.ProviderKey.Equals(ProviderKey);
         }
 
         public bool Equals(UserLoginInfo other)
         {
-            return other.LoginProvider.Equals(LoginProvider, StringComparison.InvariantCultureIgnoreCase)
-                && other.ProviderKey.Equals(ProviderKey, StringComparison.InvariantCulture);
+            return other.LoginProvider.Equals(LoginProvider)
+                && other.ProviderKey.Equals(ProviderKey);
         }
     }
 }

--- a/src/AspNetCore.Identity.MongoDB/MongoConfig.cs
+++ b/src/AspNetCore.Identity.MongoDB/MongoConfig.cs
@@ -1,5 +1,5 @@
 using Dnx.Identity.MongoDB.Models;
-using Microsoft.AspNet.Identity;
+using Microsoft.AspNetCore.Identity;
 using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.Conventions;
 using System;

--- a/src/AspNetCore.Identity.MongoDB/MongoIdentityUser.cs
+++ b/src/AspNetCore.Identity.MongoDB/MongoIdentityUser.cs
@@ -230,7 +230,7 @@ namespace Dnx.Identity.MongoDB
 
         private static string GenerateId(string userName)
         {
-            return userName.ToLower(CultureInfo.InvariantCulture);
+            return userName.ToLower();
         }
     }
 }

--- a/src/AspNetCore.Identity.MongoDB/MongoUserStore.cs
+++ b/src/AspNetCore.Identity.MongoDB/MongoUserStore.cs
@@ -1,13 +1,13 @@
-using Microsoft.AspNet.Identity;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using System.Threading;
 using MongoDB.Driver;
-using Microsoft.Extensions.Logging;
 using Dnx.Identity.MongoDB.Models;
 using System.Linq;
 using System.Security.Claims;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging;
 using MongoDB.Bson.Serialization.Conventions;
 
 namespace Dnx.Identity.MongoDB

--- a/src/AspNetCore.Identity.MongoDB/project.json
+++ b/src/AspNetCore.Identity.MongoDB/project.json
@@ -7,15 +7,15 @@
   "licenseUrl": "https://github.com/tugberkugurlu/AspNetCore.Identity.MongoDB/blob/master/LICENSE",
 
   "dependencies": {
-    "Microsoft.AspNet.Identity": "3.0.0-rc1-final",
-    "Microsoft.Extensions.Logging.Abstractions": "1.0.0-rc1-final"
+    "NETStandard.Library": "1.6.0",
+    "Microsoft.AspNetCore.Identity": "1.0.0",
+    "Microsoft.Extensions.Logging.Abstractions": "1.0.0",
+    "MongoDB.Driver": "2.3.0-beta1"
   },
 
   "frameworks": {
-    "net451": {
-      "dependencies": {
-        "MongoDB.Driver":  "2.0.1"
-      }
+    "netstandard1.6": {
+      "imports": "dnxcore50"
     }
   }
 }

--- a/src/AspNetCore.Identity.MongoDB/project.json
+++ b/src/AspNetCore.Identity.MongoDB/project.json
@@ -10,7 +10,8 @@
     "NETStandard.Library": "1.6.0",
     "Microsoft.AspNetCore.Identity": "1.0.0",
     "Microsoft.Extensions.Logging.Abstractions": "1.0.0",
-    "MongoDB.Driver": "2.3.0-beta1"
+    "MongoDB.Driver": "2.3.0-beta1",
+    "System.Collections.Specialized": "4.0.1"
   },
 
   "frameworks": {


### PR DESCRIPTION
Various changes to update AspNetCore.Identity.MongoDB to use the new MongoDb C# driver (pre).

Allows AspNetCore.Identity.MongoDB to run in asp.net core
