### PR TITLE
Fix namespaces

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,5 @@
 {
-    "projects": ["src"],
+    "projects": ["src", "samples"],
     "sdk": {
         "version": "1.0.0-preview2-003121"
     }

--- a/samples/IdentitySample.Mvc/Controllers/AccountController.cs
+++ b/samples/IdentitySample.Mvc/Controllers/AccountController.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.Extensions.Logging;
 using IdentitySample.Models.AccountViewModels;
 using IdentitySample.Services;
-using Dnx.Identity.MongoDB;
+using AspNetCore.Identity.MongoDB;
 
 namespace IdentitySample.Controllers
 {

--- a/samples/IdentitySample.Mvc/Controllers/ManageController.cs
+++ b/samples/IdentitySample.Mvc/Controllers/ManageController.cs
@@ -6,7 +6,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using IdentitySample.Models.ManageViewModels;
 using IdentitySample.Services;
-using Dnx.Identity.MongoDB;
+using AspNetCore.Identity.MongoDB;
 
 namespace IdentitySamples.Controllers
 {

--- a/samples/IdentitySample.Mvc/Startup.cs
+++ b/samples/IdentitySample.Mvc/Startup.cs
@@ -11,7 +11,7 @@ using System.IO;
 using Microsoft.Extensions.Options;
 using System.Security.Claims;
 using MongoDB.Driver;
-using Dnx.Identity.MongoDB;
+using AspNetCore.Identity.MongoDB;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.DataProtection;

--- a/samples/IdentitySample.Mvc/Views/Account/Login.cshtml
+++ b/samples/IdentitySample.Mvc/Views/Account/Login.cshtml
@@ -1,7 +1,7 @@
 @using System.Collections.Generic
 @using Microsoft.AspNetCore.Http
 @using Microsoft.AspNetCore.Http.Authentication
-@using Dnx.Identity.MongoDB
+@using AspNetCore.Identity.MongoDB
 @model LoginViewModel
 @inject SignInManager<MongoIdentityUser> SignInManager
 

--- a/samples/IdentitySample.Mvc/Views/Shared/_LoginPartial.cshtml
+++ b/samples/IdentitySample.Mvc/Views/Shared/_LoginPartial.cshtml
@@ -1,5 +1,5 @@
 @using Microsoft.AspNetCore.Identity
-@using Dnx.Identity.MongoDB
+@using AspNetCore.Identity.MongoDB
 
 @inject SignInManager<MongoIdentityUser> SignInManager
 @inject UserManager<MongoIdentityUser> UserManager

--- a/src/AspNetCore.Identity.MongoDB/Models/ConfirmationOccurrence.cs
+++ b/src/AspNetCore.Identity.MongoDB/Models/ConfirmationOccurrence.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Dnx.Identity.MongoDB.Models
+namespace AspNetCore.Identity.MongoDB.Models
 {
     public class ConfirmationOccurrence : Occurrence
     {

--- a/src/AspNetCore.Identity.MongoDB/Models/FutureOccurrence.cs
+++ b/src/AspNetCore.Identity.MongoDB/Models/FutureOccurrence.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Dnx.Identity.MongoDB.Models
+namespace AspNetCore.Identity.MongoDB.Models
 {
     public class FutureOccurrence : Occurrence
     {

--- a/src/AspNetCore.Identity.MongoDB/Models/MongoUserClaim.cs
+++ b/src/AspNetCore.Identity.MongoDB/Models/MongoUserClaim.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Security.Claims;
 
-namespace Dnx.Identity.MongoDB.Models
+namespace AspNetCore.Identity.MongoDB.Models
 {
     public class MongoUserClaim : IEquatable<MongoUserClaim>, IEquatable<Claim>
     {

--- a/src/AspNetCore.Identity.MongoDB/Models/MongoUserContactRecord.cs
+++ b/src/AspNetCore.Identity.MongoDB/Models/MongoUserContactRecord.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Dnx.Identity.MongoDB.Models
+namespace AspNetCore.Identity.MongoDB.Models
 {
     public abstract class MongoUserContactRecord : IEquatable<MongoUserEmail>
     {

--- a/src/AspNetCore.Identity.MongoDB/Models/MongoUserEmail.cs
+++ b/src/AspNetCore.Identity.MongoDB/Models/MongoUserEmail.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Dnx.Identity.MongoDB.Models
+namespace AspNetCore.Identity.MongoDB.Models
 {
     public class MongoUserEmail : MongoUserContactRecord
     {

--- a/src/AspNetCore.Identity.MongoDB/Models/MongoUserLogin.cs
+++ b/src/AspNetCore.Identity.MongoDB/Models/MongoUserLogin.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using Microsoft.AspNetCore.Identity;
 
-namespace Dnx.Identity.MongoDB.Models
+namespace AspNetCore.Identity.MongoDB.Models
 {
     public class MongoUserLogin : IEquatable<MongoUserLogin>, IEquatable<UserLoginInfo>
     {

--- a/src/AspNetCore.Identity.MongoDB/Models/MongoUserPhoneNumber.cs
+++ b/src/AspNetCore.Identity.MongoDB/Models/MongoUserPhoneNumber.cs
@@ -1,4 +1,4 @@
-﻿namespace Dnx.Identity.MongoDB.Models
+﻿namespace AspNetCore.Identity.MongoDB.Models
 {
     public class MongoUserPhoneNumber : MongoUserContactRecord
     {

--- a/src/AspNetCore.Identity.MongoDB/Models/Occurrence.cs
+++ b/src/AspNetCore.Identity.MongoDB/Models/Occurrence.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Dnx.Identity.MongoDB.Models
+namespace AspNetCore.Identity.MongoDB.Models
 {
     public class Occurrence
     {

--- a/src/AspNetCore.Identity.MongoDB/MongoConfig.cs
+++ b/src/AspNetCore.Identity.MongoDB/MongoConfig.cs
@@ -1,11 +1,11 @@
-using Dnx.Identity.MongoDB.Models;
+using AspNetCore.Identity.MongoDB.Models;
 using Microsoft.AspNetCore.Identity;
 using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.Conventions;
 using System;
 using System.Threading;
 
-namespace Dnx.Identity.MongoDB
+namespace AspNetCore.Identity.MongoDB
 {
     internal static class MongoConfig
     {
@@ -71,7 +71,7 @@ namespace Dnx.Identity.MongoDB
                 new CamelCaseElementNameConvention(),
             };
 
-            ConventionRegistry.Register("Dnx.Identity.MongoDB", pack, IsConventionApplicable);
+            ConventionRegistry.Register("AspNetCore.Identity.MongoDB", pack, IsConventionApplicable);
         }
 
         private static bool IsConventionApplicable(Type type)

--- a/src/AspNetCore.Identity.MongoDB/MongoIdentityUser.cs
+++ b/src/AspNetCore.Identity.MongoDB/MongoIdentityUser.cs
@@ -1,9 +1,9 @@
 using System;
 using System.Collections.Generic;
-using Dnx.Identity.MongoDB.Models;
+using AspNetCore.Identity.MongoDB.Models;
 using System.Security.Claims;
 
-namespace Dnx.Identity.MongoDB
+namespace AspNetCore.Identity.MongoDB
 {
     public class MongoIdentityUser
     {

--- a/src/AspNetCore.Identity.MongoDB/MongoIdentityUser.cs
+++ b/src/AspNetCore.Identity.MongoDB/MongoIdentityUser.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using Dnx.Identity.MongoDB.Models;
-using System.Globalization;
 using System.Security.Claims;
 
 namespace Dnx.Identity.MongoDB

--- a/src/AspNetCore.Identity.MongoDB/MongoUserStore.cs
+++ b/src/AspNetCore.Identity.MongoDB/MongoUserStore.cs
@@ -3,14 +3,14 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using System.Threading;
 using MongoDB.Driver;
-using Dnx.Identity.MongoDB.Models;
+using AspNetCore.Identity.MongoDB.Models;
 using System.Linq;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Logging;
 using MongoDB.Bson.Serialization.Conventions;
 
-namespace Dnx.Identity.MongoDB
+namespace AspNetCore.Identity.MongoDB
 {
     public class MongoUserStore<TUser> : 
         IUserStore<TUser>,


### PR DESCRIPTION
Fixes #10, adopting `AspNetCore.Identity.MongoDB` namespace.
